### PR TITLE
Remove ambiguity

### DIFF
--- a/templates/explorer/faq.html
+++ b/templates/explorer/faq.html
@@ -89,7 +89,7 @@
                 <p>Specifically, the infrastructure includes: </p>
                 <ul class="mx-3">
                     <li>1 x "basic" dual-core, 4GB RAM web-front-end -- note that "basic" doesn't specify the exact CPU specs</li>
-                    <li><strike>4</strike>8 x "basic" quad-core, 8GB RAM worker instances (temporarily scaled up to better handle launch load)</li> 
+                    <li>8 x "basic" quad-core, 8GB RAM worker instances (previously 4, temporarily scaled up to better handle launch load)</li> 
                 </ul>
             </section>
             <section id="how-can-i-contribute">


### PR DESCRIPTION
&lt;strike&gt;4&lt;/strike&gt; looks a lot like normal 4 (here: <strike>4</strike>)

![image](https://user-images.githubusercontent.com/24441708/178974658-49225e5c-750a-4906-adaf-ed25f21972ca.png)
