### PR TITLE
Bump angr

### DIFF
--- a/runners/decompiler/Dockerfile
+++ b/runners/decompiler/Dockerfile
@@ -44,7 +44,7 @@ ENTRYPOINT [ "./entrypoint.sh", "decompile_bn.py" ]
 
 # angr
 FROM base-x86 as angr
-RUN pip install --user 'angr>=9.2.1,<10.0'
+RUN pip install --user 'angr>=9.2.10,<10.0'
 COPY decompile_angr.py .
 
 COPY entrypoint.sh .

--- a/runners/decompiler/decompile_angr.py
+++ b/runners/decompiler/decompile_angr.py
@@ -6,6 +6,8 @@ import angr
 from angr.analyses import CFGFast, Decompiler
 from angr.knowledge_plugins import Function
 
+import warnings
+warnings.filterwarnings('ignore')
 
 def decompile():
     conts = sys.stdin.buffer.read()


### PR DESCRIPTION
First commit updates angr to the latest version, fixing the warning output displayed with the decompilation. Second commit sets an ignore for all warnings so that future warnings don't make it into the output.