### PR TITLE
Fix missing strings in angr decompilation results.

### DIFF
--- a/runners/decompiler/decompile_angr.py
+++ b/runners/decompiler/decompile_angr.py
@@ -22,7 +22,7 @@ def decompile():
         data_references=True,
     )
     p.analyses.CompleteCallingConventions(
-        cfg=cfg, recover_variables=True, analyze_callsites=True
+        cfg=cfg.model, recover_variables=True, analyze_callsites=True
     )
 
     funcs_to_decompile: List[Function] = [
@@ -33,7 +33,7 @@ def decompile():
 
     for func in funcs_to_decompile:
         try:
-            decompiler: Decompiler = p.analyses.Decompiler(func)
+            decompiler: Decompiler = p.analyses.Decompiler(func, cfg=cfg.model)
 
             if decompiler.codegen is None:
                 print(f"// No decompilation output for function {func.name}\n")


### PR DESCRIPTION
angr decompiler relies on information in recovered CFGs to display strings. This PR passes a CFG instance into the Decompiler analysis, which fixes the problem of strings not being displayed in angr's decompilation results.