### PR TITLE
Add support for the Relyze decompiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ runners/decompiler/tools/binja/*
 !runners/decompiler/tools/binja/.gitkeep
 runners/decompiler/tools/hexrays/.idapro
 runners/decompiler/tools/hexrays/ida
+runners/decompiler/tools/relyze/License.txt

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,3 +34,5 @@ services:
         <<: *default-decompiler-options
     hexrays:
         <<: *default-decompiler-options
+    relyze:
+        <<: *default-decompiler-options

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,3 +68,5 @@ services:
         <<: *default-decompiler-options
     hexrays:
         <<: *default-decompiler-options
+    relyze:
+        <<: *default-decompiler-options

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,6 +177,12 @@ services:
             context: runners/decompiler
             target: hexrays
 
+    relyze:
+        <<: *default-decompiler-options
+        image: ${IMAGE_NAME:-decompiler_explorer}:relyze
+        build:
+            context: runners/decompiler
+            target: relyze
 
 networks:
     backend_net:

--- a/runners/decompiler/Dockerfile
+++ b/runners/decompiler/Dockerfile
@@ -217,34 +217,37 @@ ENTRYPOINT [ "./entrypoint.sh", "decompile_hexrays.py" ]
 FROM base-x86 as relyze
 USER root
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends wget unzip
+	&& apt-get install -y --no-install-recommends wget
 RUN wget -nc --no-check-certificate -O /usr/share/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key \
 	&& wget -nc --no-check-certificate -P /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bullseye/winehq-bullseye.sources
 RUN dpkg --add-architecture i386 \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends winehq-stable \
 	&& rm -rf /var/lib/apt/lists/*
-	
+RUN wget -nc -O /innoextract_amd64.deb https://download.opensuse.org/repositories/home:/dscharrer/Debian_11/amd64/innoextract_1.9-0.1_amd64.deb \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends /innoextract_amd64.deb \
+	&& rm /innoextract_amd64.deb \
+	&& rm -rf /var/lib/apt/lists/*
+
 USER decompiler_user
 WORKDIR /home/decompiler_user
 
-RUN wget -O ./update_wine64.xml https://www.relyze.com/update?family=RLZ\&prod=core\&plat=wine\&arch=x64 \
-	&& wget -O ./Relyze_Core_wine64.zip https://www.relyze.com/$(grep -oP "(?<=<Installer>)(\S+)(?=</Installer>)" update_wine64.xml) \
-	&& rm ./update_wine64.xml
-RUN unzip ./Relyze_Core_wine64.zip -d ./RelyzeCore \
-	&& rm ./Relyze_Core_wine64.zip
+RUN wget -O ./update_win64.xml https://www.relyze.com/update?family=RLZ\&plat=win\&arch=x64 \
+	&& wget -O ./Relyze_Desktop_x_x_x_win64.exe https://www.relyze.com/$(grep -oP "(?<=<Installer>)(\S+)(?=</Installer>)" update_win64.xml) \
+	&& rm ./update_win64.xml
+RUN innoextract  -d ./RelyzeDesktop ./Relyze_Desktop_x_x_x_win64.exe \
+	&& rm ./Relyze_Desktop_x_x_x_win64.exe
 ENV WINEPREFIX=/home/decompiler_user/.wine-relyze
 RUN winecfg 2>/dev/null && wineserver --kill
 ENV WINEDLLOVERRIDES="dbghelp=n;symsrv=n"
 RUN rm -rf $WINEPREFIX/drive_c/users/decompiler_user/Documents
 RUN mkdir $WINEPREFIX/drive_c/users/decompiler_user/Documents
-RUN mkdir -p $WINEPREFIX/drive_c/ProgramData/Relyze64
-RUN ln -s /home/decompiler_user/RelyzeCore/symbols $WINEPREFIX/drive_c/ProgramData/Relyze64/Symbols
-RUN touch ./RelyzeCore/symsrv.yes
+RUN ln -s /home/decompiler_user/RelyzeDesktop/commonappdata/Relyze64 $WINEPREFIX/drive_c/ProgramData/Relyze64
 RUN mkdir -p $WINEPREFIX/drive_c/users/decompiler_user/AppData/Roaming/Relyze
 
 COPY tools/relyze/License.txt $WINEPREFIX/drive_c/users/decompiler_user/AppData/Roaming/Relyze
-COPY tools/relyze/decompiler_explorer.rb ./
+COPY tools/relyze/decompiler_explorer.rb .
 COPY decompile_relyze.py .
 COPY entrypoint.sh .
 COPY runner_generic.py .

--- a/runners/decompiler/Dockerfile
+++ b/runners/decompiler/Dockerfile
@@ -212,3 +212,40 @@ COPY decompile_hexrays.py .
 COPY entrypoint.sh .
 COPY runner_generic.py .
 ENTRYPOINT [ "./entrypoint.sh", "decompile_hexrays.py" ]
+
+# Relyze
+FROM base-x86 as relyze
+USER root
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends wget unzip
+RUN wget -nc --no-check-certificate -O /usr/share/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key \
+	&& wget -nc --no-check-certificate -P /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bullseye/winehq-bullseye.sources
+RUN dpkg --add-architecture i386 \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends winehq-stable \
+	&& rm -rf /var/lib/apt/lists/*
+	
+USER decompiler_user
+WORKDIR /home/decompiler_user
+
+RUN wget -O ./update_wine64.xml https://www.relyze.com/update?family=RLZ\&prod=core\&plat=wine\&arch=x64 \
+	&& wget -O ./Relyze_Core_wine64.zip https://www.relyze.com/$(grep -oP "(?<=<Installer>)(\S+)(?=</Installer>)" update_wine64.xml) \
+	&& rm ./update_wine64.xml
+RUN unzip ./Relyze_Core_wine64.zip -d ./RelyzeCore \
+	&& rm ./Relyze_Core_wine64.zip
+ENV WINEPREFIX=/home/decompiler_user/.wine-relyze
+RUN winecfg 2>/dev/null && wineserver --kill
+ENV WINEDLLOVERRIDES="dbghelp=n;symsrv=n"
+RUN rm -rf $WINEPREFIX/drive_c/users/decompiler_user/Documents
+RUN mkdir $WINEPREFIX/drive_c/users/decompiler_user/Documents
+RUN mkdir -p $WINEPREFIX/drive_c/ProgramData/Relyze64
+RUN ln -s /home/decompiler_user/RelyzeCore/symbols $WINEPREFIX/drive_c/ProgramData/Relyze64/Symbols
+RUN touch ./RelyzeCore/symsrv.yes
+RUN mkdir -p $WINEPREFIX/drive_c/users/decompiler_user/AppData/Roaming/Relyze
+
+COPY tools/relyze/License.txt $WINEPREFIX/drive_c/users/decompiler_user/AppData/Roaming/Relyze
+COPY tools/relyze/decompiler_explorer.rb ./
+COPY decompile_relyze.py .
+COPY entrypoint.sh .
+COPY runner_generic.py .
+ENTRYPOINT [ "./entrypoint.sh", "decompile_relyze.py" ]

--- a/runners/decompiler/decompile_relyze.py
+++ b/runners/decompiler/decompile_relyze.py
@@ -14,7 +14,7 @@ def relyze_cli_run(params):
     logfile = Path('log.tmp')
 
     cli = subprocess.run(['wine64', str(RELYZE_CLI), '/output', logfile.name] + params, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-    
+
     logdata = ''
 
     if logfile.is_file():
@@ -31,16 +31,18 @@ def main():
 
     infile  = Path('in.tmp')
     outfile = Path('out.tmp')
-    
+
     with open(infile.name, 'wb') as f:
         f.write(sys.stdin.buffer.read())
 
+    func_timeout = int(os.getenv('DECOMPILER_FUNC_TIMEOUT', 15))
+
     success, res = relyze_cli_run([
-        '/run', 
-        '/plugin', 
-        'decompiler_explorer.rb', 
-        '/plugin_commandline', 
-        f'/in={infile.name} /out={outfile.name}'
+        '/run',
+        '/plugin',
+        'decompiler_explorer.rb',
+        '/plugin_commandline',
+        f'/in={infile.name} /out={outfile.name} /func_timeout={func_timeout}'
     ])
 
     os.remove(infile.name)
@@ -57,7 +59,7 @@ def main():
     else:
         print('no output file.')
         return 1
-    
+
     return 0
 
 def version():

--- a/runners/decompiler/decompile_relyze.py
+++ b/runners/decompiler/decompile_relyze.py
@@ -1,0 +1,84 @@
+import re
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+RELYZE_INSTALL = Path(os.getenv("RELYZE_INSTALL_PATH", "/home/decompiler_user/RelyzeCore"))
+RELYZE_CLI     = RELYZE_INSTALL / 'RelyzeCLI.exe'
+
+def relyze_cli_run(params):
+    if not RELYZE_CLI.is_file():
+        return False, f'\'{RELYZE_CLI.name}\' not found.'
+
+    logfile = Path('log.tmp')
+
+    cli = subprocess.run(['wine64', str(RELYZE_CLI), '/output', logfile.name] + params, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    
+    logdata = ''
+
+    if logfile.is_file():
+        with open(logfile.name, 'r', encoding='utf-16-le') as f:
+            logdata = f.read()
+        os.remove(logfile.name)
+
+    if cli.returncode != 0:
+        return False, f'{logdata}\n{cli.stdout.decode()}'
+
+    return True, logdata
+
+def main():
+
+    infile  = Path('in.tmp')
+    outfile = Path('out.tmp')
+    
+    with open(infile.name, 'wb') as f:
+        f.write(sys.stdin.buffer.read())
+
+    success, res = relyze_cli_run([
+        '/run', 
+        '/plugin', 
+        'decompiler_explorer.rb', 
+        '/plugin_commandline', 
+        f'/in={infile.name} /out={outfile.name}'
+    ])
+
+    os.remove(infile.name)
+
+    if not success:
+        print(res)
+        os.remove(outfile.name)
+        return 1
+
+    if outfile.is_file():
+        with open(outfile.name, 'r') as f:
+            print(f.read())
+        os.remove(outfile.name)
+    else:
+        print('no output file.')
+        return 1
+    
+    return 0
+
+def version():
+    success, ver = relyze_cli_run(['/version'])
+    if not success:
+        return 1
+    match = re.findall(r'\s(\d+\.\d+\.\d+)\s', ver)
+    if len(match) == 0:
+        return 1
+    print(match[0])
+    print()
+    return 0
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == '--name':
+        print('Relyze')
+        sys.exit(0)
+    if len(sys.argv) > 1 and sys.argv[1] == '--url':
+        print('https://www.relyze.com/')
+        sys.exit(0)
+    if len(sys.argv) > 1 and sys.argv[1] == '--version':
+        sys.exit(version())
+
+    sys.exit(main())

--- a/runners/decompiler/decompile_relyze.py
+++ b/runners/decompiler/decompile_relyze.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-RELYZE_INSTALL = Path(os.getenv("RELYZE_INSTALL_PATH", "/home/decompiler_user/RelyzeCore"))
+RELYZE_INSTALL = Path(os.getenv("RELYZE_INSTALL_PATH", "/home/decompiler_user/RelyzeDesktop/app"))
 RELYZE_CLI     = RELYZE_INSTALL / 'RelyzeCLI.exe'
 
 def relyze_cli_run(params):

--- a/runners/decompiler/tools/relyze/decompiler_explorer.rb
+++ b/runners/decompiler/tools/relyze/decompiler_explorer.rb
@@ -1,0 +1,99 @@
+require 'relyze/core'
+
+class Plugin < Relyze::Plugin::Analysis
+
+    def initialize
+        super( {
+            :guid        => '{E15AF490-32DE-4548-8126-739DDA101FF0}',
+            :name        => 'Decompiler Explorer Plugin',
+            :description => 'Decompile all functions in a binary',
+            :authors     => [ 'Relyze Software Limited' ],
+            :license     => 'Relyze Plugin License',
+            :references  => [ 'https://www.relyze.com' ],
+            :options     => {
+                '/in'          => nil,
+                '/out'         => nil,
+                '/max_threads' => nil
+            }
+        } )
+        @eol = "\n"
+    end
+
+    def run
+
+        if( options['/in'].nil? or not ::File::exists?( options['/in'] ) )
+            print_message( "Error: Pass an input file via /in" )
+            return
+        end
+
+        if( options['/out'].nil? )
+            print_message( "Error: Pass an output file via /out" )
+            return
+        end
+
+        if( options['/max_threads'].nil? )
+            require 'etc'
+            options['/max_threads'] = ::Etc.nprocessors
+        end
+        
+        if( options['/max_threads'].to_i <= 0 )
+            print_message( "Error: /max_threads must be > 0" )
+            return        
+        end
+
+        model = @relyze.analyze_file( options['/in'] )
+
+        if( model.nil? )
+            print_message( "Error: Failed to analyze '#{options['/in']}'" )
+            return
+        end
+        
+        work = model.functions
+
+        pseudocode = {}
+        
+        lock = ::Mutex.new
+        
+        threads = []
+
+        1.upto( options['/max_threads'].to_i ) do
+            threads << ::Thread.new do
+                begin
+                    while true do
+                    
+                        func = lock.synchronize do
+                            work.pop
+                        end
+                        
+                        break if func.nil?
+
+                        pseudo = func.to_pseudo
+                        
+                        txt  = "// VA=0x#{ model.rva2va( func.rva ).to_s(16) }#{@eol}"
+                        txt << (pseudo.nil? ? "// Failed to decompile.#{@eol}" : pseudo.gsub!("\r\n", @eol) )
+                            
+                        lock.synchronize do
+                            pseudocode[func.rva] = txt
+                        end
+                    end                        
+                rescue
+                    print_message( "Exception in worker thread: #{$!}" )
+                end
+            end
+        end
+
+        threads.each do | thread |
+            thread.join
+        end
+        
+        pseudocode = pseudocode.sort.to_h
+        
+        ::File.open( options['/out'], "w" ) do | f |
+            pseudocode.each_value do | txt |
+                f.write( txt )
+                f.write( @eol )
+            end
+        end
+
+    end
+end

--- a/scripts/dce.py
+++ b/scripts/dce.py
@@ -40,6 +40,11 @@ if not (BASE_DIR / 'runners' / 'decompiler' / 'tools' / 'hexrays' / '.idapro' / 
 else:
     DECOMPILERS.append(('hexrays', 'Hex Rays'))
 
+if not (BASE_DIR / 'runners' / 'decompiler' / 'tools' / 'relyze' / 'License.txt').exists():
+    print("Relyze license file not detected... Excluding from build")
+else:
+    DECOMPILERS.append(('relyze', 'Relyze'))
+
 DECOMPILERS.sort(key=lambda d: d[0])
 
 parser = argparse.ArgumentParser(description='Manage decompiler explorer')

--- a/templates/explorer/faq.html
+++ b/templates/explorer/faq.html
@@ -71,6 +71,7 @@
                     <li><a href="https://hex-rays.com/ida-pro/">Hex-Rays (IDA Pro)</a></li>
                     <li><a href="https://www.backerstreet.com/rec/rec.htm">REC Studio</a></li>
                     <li><a href="https://github.com/uxmal/reko">Reko</a></li>
+                    <li><a href="https://www.relyze.com/">Relyze</a></li>
                     <li><a href="https://github.com/avast/retdec">RetDec</a></li>
                     <li><a href="https://github.com/yegord/snowman">Snowman</a></li>
                 </ul>


### PR DESCRIPTION
Hi! This pull request adds Decompiler Explorer support for the Relyze decompiler.

As Relyze is a commercial decompiler you will need a suitable license which I am happy to supply (The license will be a text file you will place in the ./runners/decompiler/tools/relyze/ directory), so just let me know the best point of contact so I can send that on, thanks.

Closes #79