### PR TITLE
Switched samples dropdown to use 'change' event instead of 'click'

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -89,6 +89,12 @@ function updateFrames() {
     });
 }
 
+function clearFrameInputs() {
+    Object.values(decompilerFrames).forEach(i => i.session.getDocument().setValue(""));
+    Object.values(decompilerFrames).forEach(i => i.resize());
+    Object.values(decompilerRerunButtons).forEach(i => i.hidden = true);
+}
+
 function displayResult(resultData, is_sample) {
     // If a new decompiler comes online before we refresh, it won't be in the list
     if (Object.keys(decompilers).indexOf(resultData['decompiler']['name']) === -1)
@@ -273,18 +279,14 @@ function rerunDecompiler(decompiler_name) {
 
 document.getElementById('file').addEventListener('change', (e) => {
     e.preventDefault();
-    Object.values(decompilerFrames).forEach(i => i.session.getDocument().setValue(""));
-    Object.values(decompilerFrames).forEach(i => i.resize());
-    Object.values(decompilerRerunButtons).forEach(i => i.hidden = true);
+    clearFrameInputs();
     uploadBinary();
 });
-document.getElementById('samples').addEventListener('click', (e) => {
+document.getElementById('samples').addEventListener('change', (e) => {
     let id = document.getElementById('samples').value;
     if (id != '') {
         e.preventDefault();
-        Object.values(decompilerFrames).forEach(i => i.session.getDocument().setValue(""));
-        Object.values(decompilerFrames).forEach(i => i.resize());
-        Object.values(decompilerRerunButtons).forEach(i => i.hidden = true);
+        clearFrameInputs();
         addHistoryEntry(id);
         loadAllDecompilers(id, true);
     }


### PR DESCRIPTION
I found that when using the samples dropdown, the click event was leading to the calls getting made when you click the dropdown, not even selecting it. And then you could get into a weird state where you click the dropdown, the event fires, then you click an option, and none of the events fire. Changing the event to listen for 'change' instead of 'click' will make it so the event only gets fired if a value is selected.

I also noticed that there was some duplicate code to clear the frame inputs, so I also refactored that into a single function.

This also fixes https://github.com/decompiler-explorer/decompiler-explorer/issues/58