### PR TITLE
Add github actions workflow to update angr

### DIFF
--- a/.github/workflows/update-angr.sh
+++ b/.github/workflows/update-angr.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+ANGR_VERSION=$(python -c "import feedparser; print(feedparser.parse('https://pypi.org/rss/project/angr/releases.xml').entries[0].title)")
+sed -i "s/^RUN pip install --user 'angr.*$/RUN pip install --user 'angr~=$ANGR_VERSION'/g" runners/decompiler/Dockerfile
+if [ ! -z "$(git diff --name-only)" ]; then
+    git checkout -b angr-$ANGR_VERSION
+    git add runners/decompiler/Dockerfile
+    git commit -m "Update angr to $ANGR_VERSION"
+    git push origin angr-$ANGR_VERSION
+    gh pr create --fill --assignee twizmwazin
+fi

--- a/.github/workflows/update-angr.yml
+++ b/.github/workflows/update-angr.yml
@@ -1,0 +1,18 @@
+name: Update angr
+
+on:
+  schedule:
+    - cron: '0 19 * * 2' # angr releases at 0 17 * * 2
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Create angr update PR
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install script dependencies
+        run: pip install --user feedparser
+      - name: Get latest angr version
+        run: ./.github/workflows/update-angr.sh


### PR DESCRIPTION
We want to make updating the angr decompiler more automatic. This workflow will run weekly, two hours after angr releases are scheduled on Tuesdays, and open a PR with the changes, allowing me or a maintainer to verify sed didn't ruin things and click merge.