### PR TITLE
Strip worker auth token

### DIFF
--- a/decompiler_explorer/settings/docker.py
+++ b/decompiler_explorer/settings/docker.py
@@ -8,7 +8,7 @@ with open('/run/secrets/db_superuser_pass', 'r') as f:
 
 
 with open('/run/secrets/worker_auth_token', 'rb') as f:
-    WORKER_AUTH_TOKEN_HASH = hashlib.sha256(f.read()).hexdigest()
+    WORKER_AUTH_TOKEN_HASH = hashlib.sha256(f.read().strip()).hexdigest()
 
 DATABASES = {
     'default': {

--- a/runners/decompiler/runner_generic.py
+++ b/runners/decompiler/runner_generic.py
@@ -74,7 +74,7 @@ class RunnerWrapper:
 
         try:
             with open('/run/secrets/worker_auth_token', 'r') as f:
-                AUTH_TOKEN = f.read()
+                AUTH_TOKEN = f.read().strip()
         except FileNotFoundError:
             self.logger.warning("Auth token file not found, using debug token")
             AUTH_TOKEN = "DEBUG_TOKEN"


### PR DESCRIPTION
This removes a newline at the end of the auth token, as HTTP headers cannot have newlines in their values.