### PR TITLE
Add light/dark/system theme toggle

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,32 @@
+/*
+ * Custom styles for Decompiler Explorer.
+ * Theme-aware values are driven by Bootstrap 5.3 [data-bs-theme] on <html>.
+ * We define our own custom-property overrides so app-specific surfaces
+ * (header, footer, banner, decompiler borders) follow the active theme.
+ */
+
+:root {
+    --de-header-bg: #F8F9FA;
+    --de-footer-bg: #F8F9FA;
+    --de-link: #000000;
+    --de-decompiler-divider: #000000;
+    --de-btn-bg: #E9ECEF;
+    --de-btn-border: #ced4da;
+    --de-banner-bg: #212529;
+    --de-banner-fg: #f8f9fa;
+}
+
+[data-bs-theme="dark"] {
+    --de-header-bg: #1b1f23;
+    --de-footer-bg: #1b1f23;
+    --de-link: #e6edf3;
+    --de-decompiler-divider: #30363d;
+    --de-btn-bg: #21262d;
+    --de-btn-border: #30363d;
+    --de-banner-bg: #0d1117;
+    --de-banner-fg: #e6edf3;
+}
+
 html, body {
     width: 100%;
     height: 100%;
@@ -5,12 +34,16 @@ html, body {
     padding: 0;
 }
 
+/* Avoid the bright flash when switching themes during initial paint. */
+html { color-scheme: light; }
+html[data-bs-theme="dark"] { color-scheme: dark; }
+
 header {
-    background: #F8F9FA;
+    background: var(--de-header-bg);
 }
 
 header a {
-    color: #000000;
+    color: var(--de-link);
     text-decoration: none;
 }
 
@@ -28,8 +61,13 @@ header h1 {
     padding: 0 10px;
 }
 
+#banner {
+    background: var(--de-banner-bg) !important;
+    color: var(--de-banner-fg) !important;
+}
+
 #queue-url {
-    color: #ffffff;
+    color: var(--de-banner-fg);
     text-decoration: underline;
 }
 
@@ -51,14 +89,14 @@ section#decompilers {
 }
 
 footer {
-    background: #F8F9FA;
+    background: var(--de-footer-bg);
 }
 
 button.btn {
-    background-color: #E9ECEF;
+    background-color: var(--de-btn-bg);
     font-size: 0.875rem;
     padding: 0.25em;
-    border: 1px solid #ced4da;
+    border: 1px solid var(--de-btn-border);
 }
 
 .decompiler {
@@ -67,7 +105,7 @@ button.btn {
 }
 
 .decompiler.with_line {
-    border-left: 1px solid #000000;
+    border-left: 1px solid var(--de-decompiler-divider);
 }
 
 .decompiler.hidden {
@@ -75,12 +113,45 @@ button.btn {
 }
 
 .decompiler_title {
-    color: #000000;
+    color: var(--de-link);
     text-decoration: none;
 }
 
 .decompiler_rerun {
     font-size: 1rem;
-    color: #000000;
+    color: var(--de-link);
     cursor: pointer;
+}
+
+/* Theme toggle button. Sits in the header next to "What is this?". */
+.theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.theme-toggle .dropdown-toggle {
+    background: var(--de-btn-bg);
+    border: 1px solid var(--de-btn-border);
+    color: var(--de-link);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    line-height: 1;
+}
+
+.theme-toggle .dropdown-toggle:focus-visible {
+    outline: 2px solid #0d6efd;
+    outline-offset: 2px;
+}
+
+.theme-toggle .dropdown-item.active {
+    background-color: rgba(13, 110, 253, 0.15);
+    color: inherit;
+}
+
+.theme-toggle .dropdown-item i {
+    width: 1.1rem;
+    text-align: center;
+    margin-right: 0.4rem;
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,5 +1,7 @@
 ace.config.set('basePath', 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.14/');
 
+const initialAceTheme = (window.DETheme && window.DETheme.aceThemeFor(window.DETheme.effective)) || 'ace/theme/chrome';
+
 let decompilerContainers = Object.fromEntries(
     Object.values(document.getElementsByClassName("decompiler_container"))
     .map(i => [i.id.replace(/(^container_)/, ''), i])
@@ -14,9 +16,16 @@ let decompilerFrames = Object.fromEntries(
         editor.setHighlightActiveLine(true);
         editor.setHighlightGutterLine(true);
         editor.session.setMode("ace/mode/c_cpp");
+        editor.setTheme(initialAceTheme);
         return [id, editor];
     })
 );
+
+document.addEventListener('de:themechange', (e) => {
+    if (!window.DETheme) return;
+    const aceTheme = window.DETheme.aceThemeFor(e.detail.effective);
+    Object.values(decompilerFrames).forEach(editor => editor.setTheme(aceTheme));
+});
 
 let decompilerTitles = Object.fromEntries(
     Object.values(document.getElementsByClassName("decompiler_title"))

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,88 @@
+/*
+ * Theme controller for Decompiler Explorer.
+ *
+ * Exposes window.DETheme with three responsibilities:
+ *   1. Persist the user's preference ('light' | 'dark' | 'auto') in localStorage.
+ *   2. Apply the resolved theme to <html data-bs-theme="..."> (Bootstrap 5.3+).
+ *   3. Broadcast a 'de:themechange' event on document so other scripts
+ *      (e.g. Ace editor setup) can react.
+ *
+ * A small inline script in <head> applies the stored theme before paint to
+ * avoid a flash of incorrect theme; this file then wires up the toggle UI.
+ */
+(function () {
+    'use strict';
+
+    const STORAGE_KEY = 'de-theme';
+    const VALID = ['light', 'dark', 'auto'];
+    const ACE_THEMES = { light: 'ace/theme/chrome', dark: 'ace/theme/tomorrow_night' };
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+
+    function getStored() {
+        const v = localStorage.getItem(STORAGE_KEY);
+        return VALID.includes(v) ? v : 'auto';
+    }
+
+    function resolve(pref) {
+        if (pref === 'auto') return media.matches ? 'dark' : 'light';
+        return pref;
+    }
+
+    function apply(pref) {
+        const effective = resolve(pref);
+        document.documentElement.setAttribute('data-bs-theme', effective);
+        document.documentElement.setAttribute('data-theme-pref', pref);
+        document.dispatchEvent(new CustomEvent('de:themechange', {
+            detail: { preference: pref, effective: effective }
+        }));
+    }
+
+    function set(pref) {
+        if (!VALID.includes(pref)) return;
+        localStorage.setItem(STORAGE_KEY, pref);
+        apply(pref);
+        syncToggleUI(pref);
+    }
+
+    function syncToggleUI(pref) {
+        document.querySelectorAll('[data-theme-value]').forEach(el => {
+            const active = el.getAttribute('data-theme-value') === pref;
+            el.classList.toggle('active', active);
+            el.setAttribute('aria-pressed', active ? 'true' : 'false');
+        });
+        const icon = document.querySelector('[data-theme-icon]');
+        if (icon) {
+            const effective = resolve(pref);
+            // fa-sun for light, fa-moon for dark, fa-circle-half-stroke for auto
+            const cls = pref === 'auto'
+                ? 'fa-solid fa-circle-half-stroke'
+                : (effective === 'dark' ? 'fa-solid fa-moon' : 'fa-solid fa-sun');
+            icon.className = cls;
+            icon.setAttribute('aria-label', `Theme: ${pref}`);
+        }
+    }
+
+    // Re-apply when OS theme changes, but only if user chose 'auto'.
+    media.addEventListener('change', () => {
+        if (getStored() === 'auto') apply('auto');
+    });
+
+    // Wire up clicks on any element with [data-theme-value="..."].
+    document.addEventListener('click', (e) => {
+        const trigger = e.target.closest('[data-theme-value]');
+        if (!trigger) return;
+        e.preventDefault();
+        set(trigger.getAttribute('data-theme-value'));
+    });
+
+    // Initial UI sync once DOM is ready (pre-paint script already set data-bs-theme).
+    document.addEventListener('DOMContentLoaded', () => syncToggleUI(getStored()));
+
+    window.DETheme = {
+        get preference() { return getStored(); },
+        get effective() { return resolve(getStored()); },
+        set: set,
+        aceThemeFor: function (effective) { return ACE_THEMES[effective]; }
+    };
+})();

--- a/templates/explorer/_theme_toggle.html
+++ b/templates/explorer/_theme_toggle.html
@@ -1,0 +1,23 @@
+{% comment %}
+Theme toggle dropdown. Included from each page header.
+The data-theme-value attributes are picked up by static/js/theme.js.
+{% endcomment %}
+<div class="theme-toggle dropdown">
+    <button class="dropdown-toggle" type="button" id="themeToggleBtn"
+            data-bs-toggle="dropdown" aria-expanded="false" aria-haspopup="true"
+            aria-label="Toggle color theme">
+        <i data-theme-icon class="fa-solid fa-circle-half-stroke" aria-hidden="true"></i>
+        <span class="visually-hidden">Toggle color theme</span>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="themeToggleBtn">
+        <li><button type="button" class="dropdown-item" data-theme-value="light">
+            <i class="fa-solid fa-sun"></i>Light
+        </button></li>
+        <li><button type="button" class="dropdown-item" data-theme-value="dark">
+            <i class="fa-solid fa-moon"></i>Dark
+        </button></li>
+        <li><button type="button" class="dropdown-item" data-theme-value="auto">
+            <i class="fa-solid fa-circle-half-stroke"></i>System
+        </button></li>
+    </ul>
+</div>

--- a/templates/explorer/faq.html
+++ b/templates/explorer/faq.html
@@ -3,6 +3,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script>
+        (function () {
+            try {
+                var pref = localStorage.getItem('de-theme');
+                if (pref !== 'light' && pref !== 'dark' && pref !== 'auto') pref = 'auto';
+                var effective = pref === 'auto'
+                    ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                    : pref;
+                document.documentElement.setAttribute('data-bs-theme', effective);
+                document.documentElement.setAttribute('data-theme-pref', pref);
+            } catch (e) { /* localStorage may be unavailable; fall through to light */ }
+        })();
+    </script>
     <meta charset="UTF-8">
     <title>Decompiler Explorer - Frequently Asked Questions</title>
     <meta name="description" content="Decompiler Explorer is an interactive online decompiler which shows equivalent C-like output of decompiled programs from many popular decompilers.">
@@ -26,7 +39,8 @@
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.14/ace.min.js" type="text/javascript" charset="utf-8"></script>
@@ -42,8 +56,9 @@
                         <h1 class="my-0">Decompiler Explorer</h1>
                     </a>
                 </div>
-                <div class="col-md-3">
-                    <a href="{% url 'explorer:faq' %}" class="float-end">What is this?</a>
+                <div class="col-md-3 d-flex align-items-center justify-content-end gap-3">
+                    <a href="{% url 'explorer:faq' %}">What is this?</a>
+                    {% include "explorer/_theme_toggle.html" %}
                 </div>
             </div>
         </div>
@@ -124,6 +139,8 @@
         </div>
     </footer>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="{% static 'js/theme.js' %}"></script>
 <script async defer data-website-id="e8f5e886-a15e-4aca-9e17-4ebed158a438" src="https://stats.ext.v35.us/yummi.js"></script>
 </body>
 </html>

--- a/templates/explorer/index.html
+++ b/templates/explorer/index.html
@@ -3,6 +3,21 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <script>
+            // Pre-paint theme application: avoids a flash of the wrong theme.
+            // Must run before any stylesheet that depends on data-bs-theme.
+            (function () {
+                try {
+                    var pref = localStorage.getItem('de-theme');
+                    if (pref !== 'light' && pref !== 'dark' && pref !== 'auto') pref = 'auto';
+                    var effective = pref === 'auto'
+                        ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                        : pref;
+                    document.documentElement.setAttribute('data-bs-theme', effective);
+                    document.documentElement.setAttribute('data-theme-pref', pref);
+                } catch (e) { /* localStorage may be unavailable; fall through to light */ }
+            })();
+        </script>
         <meta charset="UTF-8">
         <title>Decompiler Explorer</title>
         <meta name="description" content="Decompiler Explorer is an interactive online decompiler which shows equivalent C-like output of decompiled programs from many popular decompilers.">
@@ -32,7 +47,7 @@
         <link rel="manifest" href="/static/site.webmanifest">
 
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
         <link rel="stylesheet" href="{% static 'css/style.css' %}" />
 
         <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.14/ace.min.js" type="text/javascript" charset="utf-8"></script>
@@ -52,8 +67,9 @@
                         <h1 class="my-0">Decompiler Explorer</h1>
                     </a>
                 </div>
-                <div class="col-md-3">
-                    <a href="{% url 'explorer:faq' %}" class="float-end">What is this?</a>
+                <div class="col-md-3 d-flex align-items-center justify-content-end gap-3">
+                    <a href="{% url 'explorer:faq' %}">What is this?</a>
+                    {% include "explorer/_theme_toggle.html" %}
                 </div>
             </div>
         </div>
@@ -134,6 +150,8 @@
         </div>
     </footer>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="{% static 'js/theme.js' %}"></script>
 <script src="{% static 'js/index.js' %}"></script>
 <script async defer data-website-id="e8f5e886-a15e-4aca-9e17-4ebed158a438" src="https://stats.ext.v35.us/yummi.js"></script>
 </body>

--- a/templates/explorer/queue.html
+++ b/templates/explorer/queue.html
@@ -3,6 +3,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script>
+        (function () {
+            try {
+                var pref = localStorage.getItem('de-theme');
+                if (pref !== 'light' && pref !== 'dark' && pref !== 'auto') pref = 'auto';
+                var effective = pref === 'auto'
+                    ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                    : pref;
+                document.documentElement.setAttribute('data-bs-theme', effective);
+                document.documentElement.setAttribute('data-theme-pref', pref);
+            } catch (e) { /* localStorage may be unavailable; fall through to light */ }
+        })();
+    </script>
     <meta charset="UTF-8">
     <title>Decompiler Explorer - Queue</title>
     <meta name="description" content="Decompiler Explorer is an interactive online decompiler which shows equivalent C-like output of decompiled programs from many popular decompilers.">
@@ -26,7 +39,8 @@
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
 </head>
 <body>
@@ -40,8 +54,9 @@
                         <h1 class="my-0">Decompiler Explorer</h1>
                     </a>
                 </div>
-                <div class="col-md-3">
-                    <a href="{% url 'explorer:faq' %}" class="float-end">What is this?</a>
+                <div class="col-md-3 d-flex align-items-center justify-content-end gap-3">
+                    <a href="{% url 'explorer:faq' %}">What is this?</a>
+                    {% include "explorer/_theme_toggle.html" %}
                 </div>
             </div>
         </div>
@@ -61,6 +76,8 @@
         </div>
     </footer>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="{% static 'js/theme.js' %}"></script>
 <script src="{% static 'js/queue.js' %}"></script>
 <script async defer data-website-id="e8f5e886-a15e-4aca-9e17-4ebed158a438" src="https://stats.ext.v35.us/yummi.js"></script>
 </body>


### PR DESCRIPTION
## Summary
Adds a Light / Dark / System color theme toggle to the header on all pages.

- Default is **System** (respects `prefers-color-scheme`, updates live when the OS changes).
- User choice is persisted in `localStorage`.
- An inline pre-paint script in `<head>` applies the theme before stylesheets load to prevent a flash of incorrect theme.
- Bootstrap upgraded **5.1.3 → 5.3.3** to leverage native `data-bs-theme`.
- Theme-aware values in `style.css` refactored to CSS custom properties.
- Ace editor theme is kept in sync (`chrome` ↔ `tomorrow_night`) via a custom `de:themechange` event.

## Files
- New: `static/js/theme.js`, `templates/explorer/_theme_toggle.html`
- Modified: `static/css/style.css`, `static/js/index.js`, all three templates

## Test plan
- [ ] On first visit, theme matches the OS setting.
- [ ] Switching OS between light/dark updates the page live when "System" is selected.
- [ ] Selecting Light or Dark persists across reloads.
- [ ] No flash of incorrect theme on hard reload.
- [ ] Ace editors switch theme with the rest of the page.
- [ ] Header toggle works on `/`, `/faq`, `/queue`.